### PR TITLE
Add 'with' to allow chaining of methods

### DIFF
--- a/src/FactoryStory.php
+++ b/src/FactoryStory.php
@@ -2,6 +2,7 @@
 
 namespace FactoryStories;
 
+use Illuminate\Support\Collection;
 use FactoryStories\Contracts\FactoryStoryContract;
 
 /**
@@ -32,7 +33,7 @@ abstract class FactoryStory
      */
     public function times($amount)
     {
-        $this->times = $amount;
+        $this->times = (int)$amount;
 
         return $this;
     }
@@ -46,13 +47,12 @@ abstract class FactoryStory
      */
     public function create($params = [])
     {
-        if (is_int($this->times) && $this->times > 1) {
-            return collect(range(1, $this->times))
-                ->transform(function ($index) use ($params) {
-                    return $this->build($params);
-                });
+        if ($this->times <= 1) {
+            return $this->build($params);
         }
-
-        return $this->build($params);
+        
+        return Collection::times($this->times, function () use ($params) {
+            return $this->build($params);
+        });
     }
 }

--- a/src/FactoryStory.php
+++ b/src/FactoryStory.php
@@ -12,6 +12,7 @@ abstract class FactoryStory
 {
 
     protected $times = 1;
+    protected $with = null;
 
     /**
      * Here you can create your complex model factory
@@ -48,11 +49,55 @@ abstract class FactoryStory
     public function create($params = [])
     {
         if ($this->times <= 1) {
-            return $this->build($params);
+            return $this->forge($params);
         }
         
         return Collection::times($this->times, function () use ($params) {
-            return $this->build($params);
+            return $this->forge($params);
         });
+    }
+    
+    /**
+     * Add methods to be ran after initial build
+     *
+     * @param array $methods Array of method names
+     *
+     * @return FactoryStory $this Updated $with
+     */
+
+    public function with($methods = [])
+    {
+        if(!is_null($this->with)) {
+            $this->with->merge(collect($methods));
+        }
+        else {
+            $this->with = collect($methods);
+        }
+
+        return $this;
+    }
+    
+    /**
+     * Handles any creation steps that need to be done after building
+     * a story but before returning
+     *
+     * @param  array  $params Array of custom params
+     *
+     * @return Mixed
+     */
+
+    public function forge($params = [])
+    {
+        if(is_null($this->with) || $this->with->count() === 0) {
+            return $this->build($params);
+        }
+
+        $story = $this->build($params);
+
+        $this->with->reduce(function($story, $methodName) {
+            return $this->$methodName($story);
+        }, $story);
+
+        return $this->build($params);
     }
 }


### PR DESCRIPTION
This will allow use such as:

`(new UserStory)->with(['isAdmin'])->create([
    'Full Name' => 'Ben Russell'
]);`

Where your story looks like:

```
class UserStory extends FactoryStory
{
    public function build($params = [])
    {
        return factory(User::class)->create($params);
    }
    public function isAdmin(User $user)
    {
        $user->isAdmin = true;
        $user->save();
        return $user;
    }
}

```

This should let you create story "states" kinda similar to factory "states".

Let me know if you like the idea and have any suggestions or feel free to take it and implement a different way. Just currently I seem to have to make a new story for each different state, and would really like this kind of functionality in my project.